### PR TITLE
Fix the "under-constrained" problem of `DataEncoder` circuit

### DIFF
--- a/circuits/dateUtilities/dateEncoder.circom
+++ b/circuits/dateUtilities/dateEncoder.circom
@@ -1,5 +1,7 @@
 pragma circom  2.1.6;
 
+include "circomlib/circuits/comparators.circom";
+
 // (day, month, year) -> UTF-8 encoded date "YYMMDD"
 template DateEncoder() {
     signal output encoded;
@@ -10,15 +12,39 @@ template DateEncoder() {
     signal dayDecimals <-- (day \ 10);
     signal dayRest     <-- (day % 10);
 
+    component bitCheckDay = Num2Bits(4);
+    bitCheckDay.in <== dayRest;
+
+    component ltDay = LessThan(4);
+    ltDay.in[0] <== dayRest;
+    ltDay.in[1] <== 10;
+    ltDay.out === 1;
+
     dayDecimals * 10 + dayRest === day;
 
     signal monthDecimals <-- (month \ 10);
     signal monthRest     <-- (month % 10);
 
+    component bitCheckMonth = Num2Bits(4);
+    bitCheckMonth.in <== monthRest;
+    
+    component ltMonth = LessThan(4);
+    ltMonth.in[0] <== monthRest;
+    ltMonth.in[1] <== 10;
+    ltMonth.out === 1;
+
     monthDecimals * 10 + monthRest === month;
 
     signal yearDecimals <-- (year \ 10);
     signal yearRest     <-- (year % 10); 
+
+    component bitCheckYear = Num2Bits(4);
+    bitCheckYear.in <== yearRest;
+    
+    component ltYear = LessThan(4);
+    ltYear.in[0] <== yearRest;
+    ltYear.in[1] <== 10;
+    ltYear.out === 1;
 
     yearDecimals * 10 + yearRest === year;
 
@@ -28,6 +54,5 @@ template DateEncoder() {
     signal yearEncoded <== (yearDecimals * 2**8 + yearRest) + (2**4 + 2**5 + 2**12 + 2**13);
     encoded <== yearEncoded * 2**32 + monthEncoded * 2**16 + dayEncoded;
 }
-
 
 // 00110001 00110110 00110000 00110111 00110010 00110010


### PR DESCRIPTION
Close #59 

I have identified that [`DataEncoder`](https://github.com/rarimo/passport-zk-circuits/blob/9143bc77eb2bdbd174eaa61b25b11adb5ee99f61/circuits/dateUtilities/dateEncoder.circom#L13) circuit appears to be under-constrained. For example, this circuit computes dayDecimals and dayRest as follows:

```circom
    signal dayDecimals <-- (day \ 10);
    signal dayRest     <-- (day % 10);

    dayDecimals * 10 + dayRest === day;
```

For instance, when day=4, the expected assignment is {dayDicimals: 0, dayRest: 4}. However, {dayDicimals: 0, dayRest: -6} also satisfies the constraint.

To mitigate this problem, I have added the `lessthan` check for all residuals with rigorous bit-length validation. 

> To put it precisely, the modified circuit is still non-deterministic since `* 10` might overflow when the inputs are extremely large. For example, suppose `day=21888242871839275222246405745257275088548364400416034343698204186575808495568`. Then, the expected assignment is `dayDecimals=2188824287183927522224640574525727508854836440041603434369820418657580849556` and `dayRest=8`. However, `dayDecimals=21888242871839275222246405745257275088548364400416034343698204186575808495612` and `dayRest = 1` also satisfy the constraints under the default prime number of circom. However, I think this is not a problem since the callers of `DataEncoder`,  such as `DataDecoder`, seem to limit the range of inputs.